### PR TITLE
fix(core): ARC-943 automated the versioning

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,26 +1,35 @@
----
-name: Tag
-
+name: Automate Tags
 on:
   push:
     branches:
       - main
-
 jobs:
-  ## tag
-  tag:
+  #This job will bump tag number based on the (conventional) commit message.
+  update-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Set GIT_TAG
-        run: |
-          echo "VERSION=$(cat .version | tr -d " \t\n\r")" >> $GITHUB_ENV
-      - name: git-tag
-        uses: pkgdeps/git-tag-action@v2.0.1
+      - uses: actions/checkout@v3
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
         with:
-          version: ${{ env.VERSION }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          github_repo: ${{ github.repository }}
-          git_commit_sha: ${{ github.sha }}
-          git_tag_prefix: ""
+          github-token: ${{ secrets.github_token }}
+          skip-commit: 'true'
+          version-file: './.version'
+          tag-prefix: ''
+          output-file: 'false'
+
+      - name: Extract tag version
+        id: extract-tag-version
+        run: echo "TAG_VERSION=$(echo ${{ steps.changelog.outputs.tag }})" >> $GITHUB_ENV
+
+      - name: Update version file
+        run: echo "${{ env.TAG_VERSION }}" > .version
+
+      - name: Push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update version file with tag"
+          git push origin main


### PR DESCRIPTION
We already have conventional commit because of the husky.
The new github actions i added would bump the tag number based on the commit messages on that pr. (Tag number would bump based on the highest priority commit i.e. Major> Minor> Patch.)

Current project doesn't have Changelog.md so i didn't enabled that option but with this workflow we can also add Changelog.md if needed.